### PR TITLE
fix a bug in com.mogujie.tt.ui.activity.LoginActivity.java

### DIFF
--- a/mgandroid-teamtalk/project.properties
+++ b/mgandroid-teamtalk/project.properties
@@ -11,6 +11,6 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-16
+target=android-19
 android.library.reference.1=../mgimlibs
 android.library=false

--- a/mgandroid-teamtalk/res/values/tt_strings_activity_login.xml
+++ b/mgandroid-teamtalk/res/values/tt_strings_activity_login.xml
@@ -13,6 +13,7 @@
     <string name="error_invalid_password">亲，密码太短了</string>
     <string name="error_incorrect_user">请检查用户名密码是否正确</string>
     <string name="error_field_required">请输入用户名</string>
+    <string name="error_password_required">请输入密码</string>
     <string name="invalid_account">登录失败,请重试</string>
     <string name="invalid_network">请检查网络是否正常！</string>
      <string name="login_timeout">登陆超时,请重试</string>

--- a/mgandroid-teamtalk/src/com/mogujie/tt/ui/activity/LoginActivity.java
+++ b/mgandroid-teamtalk/src/com/mogujie/tt/ui/activity/LoginActivity.java
@@ -322,7 +322,7 @@ public class LoginActivity extends TTBaseActivity implements OnIMServiceListner 
 		if (TextUtils.isEmpty(mPassword)) {
 
 			// mPasswordView.setError(getString(R.string.error_field_required));
-			Toast.makeText(this, getString(R.string.error_field_required),
+			Toast.makeText(this, getString(R.string.error_password_required),
 					Toast.LENGTH_SHORT).show();
 
 			focusView = mPasswordView;

--- a/mgimlibs/project.properties
+++ b/mgimlibs/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-16
+target=android-19
 android.library=true


### PR DESCRIPTION
In previous version, if we just input username, then click "login" button with password empty, there will come out a toast showing "please input username". it is obviously not suitable.

I just add a string named "error_password_required" to show "please input password" in the above case.

In my version, to be frankly, if we leave both "username" and "password" empty, then click "login" button, there will come out "please input password". it is not that good, and we should change the logic here. it may need adjust the logic and i am not sure what you want, so leave it to you.
